### PR TITLE
support button input elements

### DIFF
--- a/src/php/MsgMeTools.php
+++ b/src/php/MsgMeTools.php
@@ -46,6 +46,9 @@ function getDOMDocumentFormInputs(\DOMDocument $domd, bool $getOnlyFirstMatches 
 		foreach ( $domd->getElementsByTagName ( "textarea" ) as $textarea ) {
 			$ret [] = $textarea;
 		}
+		foreach ( $domd->getElementsByTagName ( "button" ) as $button ) {
+			$ret [] = $button;
+		}
 		return $ret;
 	};
 	$merged = $merged ();


### PR DESCRIPTION
doesn't make a difference for Facebook, they don't use buttons with names in input elements anyway, but it does make a difference on some other sites, for example on https://auth.lib.unc.edu/ezproxy_auth.php?url=https://global.factiva.com/ha/default.aspx